### PR TITLE
Deal with the fallout of the upgrade to the latest version of ionic/c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Add the sqlite plugin to ensure that we can access the database from the javascr
 
     $ ionic plugin add https://github.com/brodysoft/Cordova-SQLitePlugin
 
+Add the whitelist plugin to ensure that we can access google maps from the javascript
+Otherwise, only loading from file URLs is supported, per:
+http://cordova.apache.org/announcements/2015/04/15/cordova-android-4.0.0.html
+
+> Network requests are blocked by default without the plugin, so install this plugin even to allow all requests, and even if you are using CSP.
+
+    $ ionic plugin add https://github.com/apache/cordova-plugin-whitelist.git#r1.0.0
+
 The checked in version does not have the default ionic plugins installed, so on
 checking this out, you also need to install the following plugins
 

--- a/eMission/config.xml
+++ b/eMission/config.xml
@@ -9,6 +9,10 @@
     </author>
   <content src="listview.html"/>
   <access origin="*"/>
+  <!-- A wildcard can be used to whitelist the entire network,
+       over HTTP and HTTPS.
+       *NOT RECOMMENDED* -->
+  <allow-navigation href="*" />
   <preference name="webviewbounce" value="false"/>
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>


### PR DESCRIPTION
…ordova

It turns out that the most recent version of ionic/cordova uses
cordova-android@4.0.0. This requires the use of the whitelist plugin to enable
access to non-file URLs.
http://cordova.apache.org/announcements/2015/04/15/cordova-android-4.0.0.html

Even after the plugin is installed, it only supports access to file:// URLs.
We need to explicitly open access to other sites in the config.xml

Doing this in the most naive way right now to unblock Jillie.
We need to think about what our tradeoff between flexibility and functionality
should be - with this, calls to other sites will require an app upgrade.

Maybe a proxying service through our own server would be a good compromise.
