### PR TITLE
Add the ability to create a magnifying glass on the map by pressing a…

### DIFF
--- a/eMission/www/lib/leaflet-plugins/angular-leaflet-directive.js
+++ b/eMission/www/lib/leaflet-plugins/angular-leaflet-directive.js
@@ -3704,11 +3704,39 @@ angular.module("leaflet-directive")
 
                     lObject.addTo(map);
 
-                    var reverseAndReturn = function(coordinates) {
-                        var retVal = [];
-                        retVal = [coordinates[1], coordinates[0]];
-                        return retVal;
-                    };
+                    /*
+                    When we start dragging, add a magnifying glass that moves with the
+                    dragging.
+                     */
+
+                    /*
+                    L.DomEvent.on(map._container, 'touchmove', function(event) {
+                        console.log("touchmove")
+                    });
+                    */
+
+                    map.on('contextmenu', function(event) {
+                        console.log("Receieved contextmenu event "+event);
+                        if (angular.isUndefined(map._glassMap)) {
+                            map._glassMap = L.magnifyingGlass({
+                                zoomOffset: 5,
+                                radius: 50,
+                                layers: [
+                                    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png'),
+                                    L.geoJson(geojson.data, geojson.options)
+                                ],
+                                fixedPosition: false,
+                                latLng: event.latlng
+                            });
+                            map.addLayer(map._glassMap);
+                            map._glassMap.startClick = Date.now();
+                        } else {
+                            if (Date.now() - map._glassMap.startClick > 3 * 1000) {
+                                map.removeLayer(map._glassMap);
+                                delete map._glassMap;
+                            }
+                        }
+                    });
 
 /*
                     L.magnifyingGlass({
@@ -3737,7 +3765,7 @@ angular.module("leaflet-directive")
 
                     var autobounds = L.featureGroup([lObject]).getBounds()
                     map.fitBounds(autobounds,
-                         {"padding": [30, 30]}
+                         {"paddingTopLeft": [30, 30], "paddingBottomRight": [50, 50]}
                     );
 
                     if(!_hasSetLeafletData){//only do this once and play with the same ref forever

--- a/eMission/www/lib/leaflet-plugins/leaflet.magnifyingglass.js
+++ b/eMission/www/lib/leaflet-plugins/leaflet.magnifyingglass.js
@@ -75,6 +75,16 @@ L.MagnifyingGlass = L.TileLayer.extend({
     this._update(evt.latlng, evt.layerPoint);
   },
 
+  _updateFromDrag: function(evt) {
+    this._update(evt.latlng, evt.layerPoint);
+  },
+
+  _updateFromTouch: function(evt) {
+    console.log("_updateFromTouch called with "+evt);
+    this._update(this._mainMap.mouseEventToLatLng(evt.touches[0]),
+        this._mainMap.mouseEventToLayerPoint(evt.touches[0]));
+  },
+
   _updateFixed: function() {
     this._update(this.options.latLng);
   },
@@ -109,6 +119,11 @@ L.MagnifyingGlass = L.TileLayer.extend({
     // forward some DOM events as Leaflet events
     L.DomEvent.addListener(this._wrapperElt, 'click', this._fireClick, this);
 
+    /*
+    this._draggableWrapper = new L.Draggable(this._wrapperElt);
+    this._draggableWrapper.enable();
+    */
+
     var opts = this.options;
 
     this.setRadius(opts.radius);
@@ -121,6 +136,8 @@ L.MagnifyingGlass = L.TileLayer.extend({
         L.DomUtil.addClass(this._wrapperElt, ('leaflet-zoom-hide'));
       } else {
         this._mainMap.on('mousemove', this._updateFromMouse, this);
+        L.DomEvent.on(this._mainMap._container, 'touchmove', this._updateFromTouch, this);
+        // this._draggableWrapper.on('drag', this._updateFromDrag, this);
         if(!this._fixedZoom) {
           this._mainMap.on('zoomend', this._updateZoom, this);
         }
@@ -146,6 +163,7 @@ L.MagnifyingGlass = L.TileLayer.extend({
     map.off('viewreset', this._updateFixed, this);
     map.off('mousemove', this._updateFromMouse, this);
     map.off('zoomend', this._updateZoom, this);
+    L.DomEvent.off(this._mainMap._container, 'touchmove', this._updateFromTouch);
     // layers must be explicitely removed before map destruction,
     // otherwise they can't be reused if the mg is re-added
     for(var i=0, l=this.options.layers.length; i<l; i++) {


### PR DESCRIPTION
…nd holding

I really think that the magnifying glass is a good way to get clarity on parts
of the map that are hiding a lot of detail. However, I haven't been able to
figure out how to do it properly. Having a fixed glass at the end points is not
flexible enough, and also seems to have issues with duplication.

With this, I try to create a glass which can be moved to the desired location.
On playing with it, it is still a bit hard to use because of the offset, and
the extreme sensitivity of the touch screen.

Leaving it in so that people can play with it.

If we choose to retain it, the relevant changes need to be moved out, at least
of angular-leaflet-directive. I should also consider submitting a pull request
to magnifying glass to add support for mobile touch devices.
